### PR TITLE
docs: add project overview and operational logs for MCP agent system

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## What
+<short description of the change>
+
+## Why
+<business or technical reason for the change>
+
+## How
+- Architecture & design decisions (ADR ref if any)
+- API/schema changes
+- Feature flags & rollout plan
+
+## Tests
+- Unit:
+- Integration:
+- E2E/Contract:
+- Coverage: __%
+
+## Security & Perf
+- SAST/SCA/Secrets/IaC/Container: OK
+- Performance budgets: OK
+
+## Risks & Rollback
+- Risks identified:
+- Rollback plan:
+
+## Docs
+- AGENTS.md/ADR/diagrams updated
+
+## Checklist
+- [ ] Conventional Commit used
+- [ ] Changelog auto-updates correctly
+- [ ] Preview environment link(s) included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Instructions
+
+Welcome! This repository contains resources for building a CLI-driven MCP agent system.
+
+The full project overview, including goals and architecture, is available in [docs/project-overview.md](docs/project-overview.md). Start there for context before making changes.
+
+## Conventions
+
+- Use clear, concise commit messages following [Conventional Commits](https://www.conventionalcommits.org/).
+- Document any new behaviors or configuration options.
+- Keep the codebase small and modular to support multiple cooperating agents.
+
+## Operational Logs
+
+These markdown files must remain up to date and merged across branches so every contributor can access current information:
+
+- [docs/changelog.md](docs/changelog.md) – track notable changes.
+- [docs/open-issues.md](docs/open-issues.md) – record open questions, decision needs, and risks. Move resolved items to the decision log.
+- [docs/decision-log.md](docs/decision-log.md) – archive resolutions with outcomes and rationale.
+- [docs/coordination-log.md](docs/coordination-log.md) – log help requests, feedback, instructions, and other coordination notes.
+
+Pull requests should follow [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,18 @@
+# Changelog
+
+This file records notable changes to the project. Keep entries in reverse chronological order.
+
+## [Unreleased]
+- Initial placeholder.
+
+<!--
+## [vX.Y.Z] - YYYY-MM-DD
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+-->

--- a/docs/coordination-log.md
+++ b/docs/coordination-log.md
@@ -1,0 +1,13 @@
+# Coordination Log
+
+Record help requests, offers, feedback, instructions, orders, and escalations among contributors.
+
+<!--
+Template:
+## YYYY-MM-DD HH:MM UTC
+- **From:** name
+- **To:** name or team
+- **Type:** request | offer | feedback | instruction | escalation
+- **Message:** summary
+- **Follow-up:** next steps
+-->

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1,0 +1,17 @@
+# Decision & Info Log
+
+Archive of resolved questions and decisions moved from `open-issues.md`.
+
+<!--
+Template:
+## [ID] - Title
+- **Date Added:** YYYY-MM-DD
+- **Version:** vX.Y.Z
+- **Branch:** https://example.com/branch
+- **Submitter:** name
+- **Decision Maker:** name
+- **Decision Date:** YYYY-MM-DD
+- **Outcome:** what was decided
+- **Rationale:** why
+- **Details:** links to commits/PRs/docs
+-->

--- a/docs/open-issues.md
+++ b/docs/open-issues.md
@@ -1,0 +1,19 @@
+# Open Issues Log
+
+Track significant open questions, decision needs, and risks. Move entries to `decision-log.md` once resolved.
+
+<!--
+Template:
+## [ID] - Title
+- **Date Added:** YYYY-MM-DD
+- **Version:** vX.Y.Z
+- **Branch:** https://example.com/branch
+- **Submitter:** name
+- **Decision Maker:** name
+- **Needed By:** YYYY-MM-DD
+- **Status:** open
+- **Problem:** description
+- **Options:**
+  - Option A - pros / cons
+  - Option B - pros / cons
+-->

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,15 @@
+# Project Overview
+
+This repository documents a "CLI-driven MCP agent system" with an **extensible retrieval-augmented generation (RAG) pipeline**, a **configurable runtime**, and a **multi-agent DevOps workflow**. The goal is to provide a reference implementation for building agents that interact through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+
+Key capabilities:
+
+- **CLI-first workflow** – interact with agents locally via the command line.
+- **Extensible RAG** – plug in different data sources for context-aware responses.
+- **Configurable runtime** – adapt transports, storage, and tools through configuration files.
+- **Multi-agent DevOps** – support specialized agents for linting, testing, deployment, and other lifecycle tasks.
+
+For additional background and context, see the original project description:
+
+<https://chatgpt.com/s/dr_68a797b295e08191aee3dc2b2523646b>
+


### PR DESCRIPTION
## What
- add AGENTS.md with pointers for coding agents
- add docs/project-overview.md summarizing CLI-driven MCP agent system
- add changelog, open-issues, decision, and coordination logs
- add PR template for consistent contributions

## Why
- document project description and operational communication for coding agents

## How
- text files only

## Tests
- Unit: `pytest`
- Integration: n/a
- E2E/Contract: n/a
- Coverage: n/a

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: n/a
- Performance budgets: n/a

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a79dd2e4fc8323b8b345f8e7b72050