### PR TITLE
docs: add Business Rules of Acquisition guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ The full project overview, including goals and architecture, is available in [do
 - Document any new behaviors or configuration options.
 - Keep the codebase small and modular to support multiple cooperating agents.
 
+## Additional Guidelines
+
+- [broa.md](broa.md) – Business Rules of Acquisition for broader wisdom on collaboration and business.
+
 ## Operational Logs
 
 These markdown files must remain up to date and merged across branches so every contributor can access current information:

--- a/broa.md
+++ b/broa.md
@@ -1,0 +1,125 @@
+# Business Rules of Acquisition
+
+*Copyright © Towo Toivola and Jukka Talvio 2006–2012*
+
+The BRoA is a collection of time-enduring wisdom about business, humans, and life. You need to deeply understand the message of each rule, going beyond the obvious written message. Good advice to inspire good ideas. That also means that some people will use it exactly the other way; twisting teachings out of proportion and context until they justify the way they were thinking in the first place.
+
+So be it.
+
+You may ignore any rule at your own peril.
+
+---
+
+## Rules
+
+1. Your business objective is the acquisition of wealth.  
+2. Make it easy for people to give you money.  
+3. Make it easy for people to tell you what they want.  
+4. Make it easy for people to find out what you want to sell.  
+5. Out-invent your enemies.  
+6. Out-focus your enemies.  
+7. If you cannot beat your enemies, learn.  
+8. If something is stupid, stop doing it.  
+9. If you don't know how you are doing, find out.  
+10. Quality is a weapon in acquiring wealth.  
+11. If you don't know something, ask the people who do.  
+12. You need to control costs in order to win.  
+13. You need to spend the money you need to spend.  
+14. Two brains think much more than twice as much as one.  
+15. Do not ascribe to malice, that which can be explained by incompetence.  
+16. Always keep in mind the people who give you money.  
+17. To hell with the details, get the important things right.  
+18. When concentrating on facts, remember that if people feel a certain way, that is a fact.  
+19. Do not try to fool people below you, they are often smart and will think you are stupid or at least incompetent.  
+20. Never underestimate people’s unconditional faith in a rosy future.  
+21. When you are confronted, always consider that the other person may be right.  
+22. Don’t argue for the sake of terminology. The biggest fights are between people who say the same opinion in different ways.  
+23. The right choice is always between the extremes, just not always in the middle.  
+24. Know your enemies.  
+25. Know your allies.  
+26. Professionalism is not the absence of fun. Absense of fun is unprofessional.  
+27. Catering is cheap, overtime is expensive.  
+28. Only engage in battles you have already won.  
+29. Respect is not cheap, but you can not afford disrespect.  
+30. When you argue, the one with financial numbers is on high ground.  
+31. If something needs to be done, get on with it.  
+32. If something makes more sense than something else, concentrate on the former.  
+33. You can only engage problems that you accept you have.  
+34. The most important bits of information are the ones which hurt the most.  
+35. Tough businessmen are all vertebrates, they are soft on the outside and have a sturdy spine in the middle.  
+36. In a world where everyone's main goal is the pursuit of happiness, you can't afford to ignore feelings.  
+37. Not everyone will be your friend and not everyone will be your enemy, but everyone can be your teacher if you are willing to listen.  
+38. ROI is your friend and ally. If you do not know ROI, be very afraid.  
+39. Value good customers, for they are as rare as latinum. Hold on to them.  
+40. If you need to make a decision, make it. It is better to fix it later than to wander aimlessly forever.  
+41. Try new tactics, as it makes much more sense to fail in new ways rather than in old ways.  
+42. In your industry, there are only two problems: Customers and employees.  
+43. Be careful of what you measure, for that is what you will get, and only that.  
+44. Be ready to deal out praise, in case an opportunity presents itself.  
+45. It is good to grow, but do not use hormones.  
+46. Good employees are as rare as latinum. Treasure them.  
+47. Never underestimate the power of professional pride.  
+48. Assign only meaningful tasks.  
+49. If you deal out responsibility deal authority with it.  
+50. Only aim for 80 % efficiency.  
+51. Real learning makes a sound. The sound is “Oh shit”.  
+52. Advice without thought is meaningless. Like this one.  
+53. If you learn something and change nothing, you didn't learn anything.  
+54. Self respect is priceless, everything else you can buy.  
+55. If that which you believe in brings you only happiness, you are fooling yourself.  
+56. The two ways for an easy life are acceptance and denial.  
+57. Each rule has an equal, but opposite, evil rule of non-business.  
+58. If you fix something more than twice, maybe you're not fixing it.  
+59. All things you can do too much and too little, including loitering around the coffee maker.  
+60. It is not stupid to bill big, but to pay big.  
+61. If it is important, it must be written down before it escapes.  
+62. World is not fair. Understand this.  
+63. World is not supposed to be anything, the world is.  
+64. What people say, do, and think do not necessarily correlate in any way.  
+65. Accept the things you cannot change, they are called the environment.  
+66. Have the balls to change the things you can. Most things you believe to be the environment, aren't.  
+67. The more accurately you plan, the further ahead, the more you will be surprised.  
+68. If you don't know who is in charge, should you be?  
+69. Advantages are taken, not handed out.  
+70. Don’t do anything that no one is willing to pay for.  
+71. Include also the time spent fooling around.  
+72. The best product nobody knew about never made no money.  
+73. Don’t just push, find pull. Or if need be, generate the pull.  
+74. In a confrontation there is fault in both ends, every single time.  
+75. Stop doing to others the things that irritate you in other people.  
+76. If you like something it does not necessarily mean other people will like it.  
+77. There is no question whether you will provide a customer with what he wants. The only question is how much you will charge.  
+78. If you move work around and call it different names, it does not change the amount of the work.  
+79. Everything seems simpler to the people who are not doing it.  
+80. Everything seems more important to the people who are doing it.  
+81. There will always be high-maintenance and low-maintenance people. Both can be assets if you deal with them correctly.  
+82. Physical age is no indication of whether someone will behave in an adult manner or not.  
+83. Finding out who is to blame is not that important. Blaming rarely helps in any situation. Solutions are much more useful than blame, though not nearly as much fun.  
+84. If things always went the way they should, there wouldn't be any wars, would there?  
+85. At least half of people are more stupid than average.  
+86. The right 20 % of the effort brings you 80 % of the benefits.  
+87. Whoever is quicker to change will win the war.  
+88. A little bit right now weighs a load more than promises of a glorious future.  
+89. What people want, changes with calendar time.  
+90. People are like lions, they are easier to live with when they are fed.  
+91. Making noise is proper, but try to make quality noise.  
+92. It is natural and beneficial for people to create boxes for themselves.  
+93. It is unnatural and painful, but totally necessary to visit the outside of your box.  
+94. The amount of employee control you need is inversely proportional to the trust you have for them.  
+95. Lying to others is bad for you in the long run, lying to yourself is just plain stupid.  
+96. There are no substitutes for talking to people.  
+97. People are different. Make this work for you. Never work against it.  
+98. If you do not consider the receiver when creating the message, why bother?  
+99. Your work career is there to support your life, not the other way around.  
+100. You are never going to do anything that everyone agrees with.  
+101. Keep it simple. You will have numerous opportunities to make it fancy later. If you must.  
+102. Don’t use precious time for something that can be bought for less.  
+103. Build your castle one tower at a time.  
+104. Insanity: doing the same thing over and over again and expecting different results.  
+105. While lesser men focus on how to get something done, you shall make sure it is the right things that are done.  
+106. You can use overtime in the short term for dealing with unexpected problems, or in the long term to produce a false sense of productivity.  
+107. Assumption is the mother of all fuck-ups.  
+108. Have a guiding vision. And share it!  
+109. If you don't know why you are in a meeting, find out or get out.  
+110. Thou shalt not build on things that are broken.  
+111. You must put results before personal glory. Glory will find your hiding place.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@ This file records notable changes to the project. Keep entries in reverse chrono
 
 ## [Unreleased]
 - Initial placeholder.
+- Added Business Rules of Acquisition guidelines and linked them from AGENTS.md.
 
 <!--
 ## [vX.Y.Z] - YYYY-MM-DD

--- a/docs/coordination-log.md
+++ b/docs/coordination-log.md
@@ -11,3 +11,10 @@ Template:
 - **Message:** summary
 - **Follow-up:** next steps
 -->
+
+## 2025-08-21 23:11 UTC
+- **From:** user
+- **To:** contributors
+- **Type:** instruction
+- **Message:** Include Business Rules of Acquisition as broa.md and link from AGENTS.md.
+- **Follow-up:** Document added and linked.


### PR DESCRIPTION
## What
- add Business Rules of Acquisition document and link from AGENTS

## Why
- record additional guideline requested by user

## How
- link from AGENTS
- update changelog and coordination log

## Tests
- Unit: none
- Integration: none
- E2E/Contract: none
- Coverage: 0%

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [x] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a7a76b65808323bfbb721ca682cfa4