### PR TITLE
docs: add AI-augmented engineering handbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Welcome! This repository contains resources for building a CLI-driven MCP agent 
 
 The full project overview, including goals and architecture, is available in [docs/project-overview.md](docs/project-overview.md). Start there for context before making changes.
 Guidelines for human and AI agent collaboration based on the Business Rules of Acquisition are in [docs/broa-agent-guidelines.md](docs/broa-agent-guidelines.md).
+An engineering handbook with principles and practices for AI-augmented software teams is available in [docs/engineering-handbook.md](docs/engineering-handbook.md).
 
 
 ## Conventions
@@ -15,6 +16,7 @@ Guidelines for human and AI agent collaboration based on the Business Rules of A
 ## Additional Guidelines
 
 - [broa.md](broa.md) – Business Rules of Acquisition for broader wisdom on collaboration and business.
+- [docs/engineering-handbook.md](docs/engineering-handbook.md) – Playbook for humans and AI agents collaborating on software delivery.
 
 ## Operational Logs
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ This file records notable changes to the project. Keep entries in reverse chrono
 - Add BRoA-based guidelines for human and AI agent collaboration.
 - Initial placeholder.
 - Added Business Rules of Acquisition guidelines and linked them from AGENTS.md.
+- Added engineering handbook outlining principles and practices for AI-augmented teams.
 
 <!--
 ## [vX.Y.Z] - YYYY-MM-DD

--- a/docs/coordination-log.md
+++ b/docs/coordination-log.md
@@ -18,3 +18,10 @@ Template:
 - **Type:** instruction
 - **Message:** Include Business Rules of Acquisition as broa.md and link from AGENTS.md.
 - **Follow-up:** Document added and linked.
+
+## 2025-08-21 23:54 UTC
+- **From:** user
+- **To:** contributors
+- **Type:** instruction
+- **Message:** Implement engineering handbook and guidelines for humans and AI agents.
+- **Follow-up:** Handbook added and AGENTS.md updated.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -25,3 +25,14 @@ Template:
 - **Outcome:** Adopted BRoA-based guidelines for human and AI agent collaboration.
 - **Rationale:** Provide shared principles for working with AI agents and mixed human–AI teams.
 - **Details:** See [docs/broa-agent-guidelines.md](broa-agent-guidelines.md).
+
+## [0002] - Adopt AI-Augmented Engineering Handbook
+- **Date Added:** 2025-08-21
+- **Version:** Unreleased
+- **Branch:** main
+- **Submitter:** automated agent
+- **Decision Maker:** project maintainers
+- **Decision Date:** 2025-08-21
+- **Outcome:** Adopted comprehensive engineering handbook for humans and AI agents.
+- **Rationale:** Provide evidence-based principles and practices to guide collaboration and delivery.
+- **Details:** See [docs/engineering-handbook.md](engineering-handbook.md).

--- a/docs/engineering-handbook.md
+++ b/docs/engineering-handbook.md
@@ -1,0 +1,72 @@
+# Engineering Handbook for AI-Augmented Teams
+
+This playbook outlines principles and practices for humans and AI agents collaborating on software delivery. It is adapted from evidence-based industry research and should guide day-to-day work.
+
+## Principles (What to Optimize For)
+- **Fast, safe flow of value**: work in small batches with frequent integration and delivery. Measure using the four key outcomes (Deployment Frequency, Lead Time, Change Failure Rate, Mean Time to Restore).
+- **Work on outcomes, not output**: follow Agile values and 12 principles alongside Lean software development principles (eliminate waste, build quality in, defer commitment, deliver fast, empower people, build integrity in, optimize the whole).
+- **Reliability as a feature**: use SLOs and error budgets to govern the pace of change and prioritization.
+- **Cross-functional, stream-aligned teams**: reduce handoffs, leverage platform/enabling teams to lower cognitive load, and maintain psychological safety.
+- **XP mindset**: apply simple design, TDD, refactoring, pair/mob programming, collective ownership, and continuous integration.
+- **Continuous discovery & early validation**: test assumptions before building through dual-track discovery/delivery, RATs, and build-measure-learn loops.
+- **AI-agent augmentation, not autopilot**: use instrumented, least-privilege tools via open protocols, secure against LLM-specific risks, and evaluate agents on real software tasks.
+
+## Practices (How to Implement)
+
+### 1. Planning, Prioritization & Feedback
+- Set one Product Goal leading to Sprint Goals; maintain a clear Definition of Done.
+- Run dual-track: weekly discovery loops (interviews, assumption tests, rapid prototypes) in parallel with delivery.
+- Prioritize by value & speed using WSJF (Cost of Delay / Duration) and RICE (Reach × Impact × Confidence / Effort).
+- Hold retrospectives each iteration with explicit actions.
+
+### 2. Architecture & Code Quality
+- Use trunk-based development (≤3 active branches; daily merges; no code freezes). Ship safely with feature flags and branch-by-abstraction.
+- Review code for health (design, tests, simplicity, readability) with small PRs.
+- Practice TDD and refactoring, aiming for a healthy test pyramid (many fast unit tests, fewer service/UI tests).
+
+### 3. Testing & Risk Reduction
+- Test the riskiest assumptions first (feasibility, value, compliance). Prefer cheap experiments over building.
+- Keep tests fast, reliable, and readable; classify by size (small/medium/large) to keep pipelines quick.
+
+### 4. CI/CD, DevOps & SRE
+- Automate the pipeline: build → test → security scan → artifact → deploy → verify → rollback on failure. Ship on demand.
+- Use progressive delivery (canary/blue-green) behind flags; tie observability and auto-rollback to SLO alerts.
+- Track DORA metrics as the north star for software delivery performance.
+
+### 5. AI Coding Agents — Team Setup, Rules & Guardrails
+- **Tooling architecture**: standardize agent tool access via MCP; version prompts, tools, and policies as code; capture full telemetry of agent steps.
+- **Safety & compliance**: apply OWASP LLM Top 10 and NIST AI RMF; sandbox agents, allow-list tools, secret-scan all diffs, and require human approval for destructive operations.
+- **Evaluation & QA**: benchmark agent changes on SWE-bench (Verified)/SWE-Gym before rollout; track cost, success rate, and regressions.
+- **Operational limits**: set budgets (tokens/time), provide a kill switch and escalation routes, and ensure reproducible runs with logged seeds and configs. Treat agent tools as production-grade integrations.
+- **Suggested roles**:
+  - *Humans*: Product lead, Tech lead/architect, Platform/DevEx, SRE, Security, QA/SET, Designer.
+  - *Agents*: Planner/orchestrator, Coder, Reviewer/Linter, Test-writer, Security scanner, Docs/Changelog bot, CI operator. Map agents to tools with least privilege via MCP.
+
+### 6. Team Topology, Skills & Soft Skills
+- Organize around stream-aligned teams; use platform/enabling teams to reduce cognitive load and accelerate flow.
+- Invest in psychological safety; encourage speaking up and sharing mistakes.
+- Core skills include outcome-driven product thinking, readable code, test design, observability, incident management, secure-by-default practices, data literacy, and prompt/tool design for agents.
+
+## Minimal Golden Rules (One-Pager)
+1. Ship small to trunk daily; gate with CI; hide behind flags.
+2. Keep SLOs and error budgets; freeze features when budgets are burned.
+3. Practice TDD on critical paths; maintain a steep test pyramid.
+4. Run discovery every week; test riskiest assumptions first.
+5. Standardize agent tools via MCP; enforce LLM security controls; benchmark agents before rollout.
+6. Measure with DORA metrics; improve with retrospectives.
+
+## Selected Sources
+- Agile Manifesto & Principles; Lean software development principles.
+- DORA research on CI/CD and trunk-based development; *Continuous Delivery*.
+- Google Engineering Practices: code review; test sizing; Fowler's Test Pyramid.
+- Site Reliability Engineering: SLOs, error budgets, alerting on SLOs.
+- AI agents: MCP specification; OWASP LLM Top 10; SWE-bench/SWE-Gym.
+- Team Topologies; psychological safety (Project Aristotle).
+- Community reflections on CI/TBD and dual-track agile debates.
+
+## Assumptions
+- Modern cloud-hosted service, Git-based workflow, automated CI available, MCP-capable agent stack planned.
+
+## Confidence
+- 88% — breadth of guidance is high, but specific organizational constraints may require tailoring. Adjust this handbook as the team learns and evolves.
+


### PR DESCRIPTION
## What
- add engineering handbook with principles and practices for AI-augmented teams
- reference handbook from AGENTS.md and update project logs

## Why
- document playbook for humans and agents collaborating on software delivery

## How
- Architecture & design decisions (ADR ref if any)
- API/schema changes
- Feature flags & rollout plan

## Tests
- Unit:
- Integration:
- E2E/Contract:
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: N/A
- Performance budgets: N/A

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated: yes

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a7b1675c108323a162c3245b867a11