### PR TITLE
ci: run tests in mock mode to avoid network/API deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
   test:
     name: Tests (pytest + coverage)
     runs-on: ubuntu-latest
+    env:
+      AGENTSMCP_TEST_MODE: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    env:
+      AGENTSMCP_TEST_MODE: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +30,7 @@ jobs:
           python -m pip install ruff
           ruff check src
 
-      - name: Run tests
+      - name: Run tests (mock mode)
         run: |
           pytest -q
 


### PR DESCRIPTION
Set AGENTSMCP_TEST_MODE=1 in CI workflows so pytest runs without requiring real API keys or network access.